### PR TITLE
Extracts types into different files for easier importing

### DIFF
--- a/dist/models/TransactionType.js
+++ b/dist/models/TransactionType.js
@@ -1,0 +1,7 @@
+export var TransactionType;
+(function (TransactionType) {
+    TransactionType["Swap"] = "swap";
+    TransactionType["Deposit"] = "deposit";
+    TransactionType["Remove"] = "remove";
+})(TransactionType || (TransactionType = {}));
+//# sourceMappingURL=TransactionType.js.map

--- a/dist/models/TransactionType.js.map
+++ b/dist/models/TransactionType.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"TransactionType.js","sourceRoot":"","sources":["../../src/models/TransactionType.ts"],"names":[],"mappings":"AAAA,MAAM,CAAN,IAAY,eAIX;AAJD,WAAY,eAAe;IACzB,gCAAa,CAAA;IACb,sCAAmB,CAAA;IACnB,oCAAiB,CAAA;AACnB,CAAC,EAJW,eAAe,KAAf,eAAe,QAI1B"}

--- a/dist/utils/postgresTables/readFunctions/SandwichDetail.js
+++ b/dist/utils/postgresTables/readFunctions/SandwichDetail.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=SandwichDetail.js.map

--- a/dist/utils/postgresTables/readFunctions/SandwichDetail.js.map
+++ b/dist/utils/postgresTables/readFunctions/SandwichDetail.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"SandwichDetail.js","sourceRoot":"","sources":["../../../../src/utils/postgresTables/readFunctions/SandwichDetail.ts"],"names":[],"mappings":""}

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -3,7 +3,7 @@ import { topBestPerformingLabels, topWorstPerformingLabels } from './utils/helpe
 import {
   SandwichDetail,
   SandwichTableContent,
-} from './utils/postgresTables/readFunctions/SandwichDetailEnrichments.js';
+} from './utils/postgresTables/readFunctions/SandwichDetail.js';
 import {
   ArbBotLeaderBoardbyTxCount,
   AtomicArbTableContent,
@@ -11,7 +11,10 @@ import {
   DurationInput,
   EnrichedTransactionDetail,
   IntervalInput,
+  LabelRankingExtended,
+  LabelRankingShort,
   TransactionDetailsForAtomicArbs,
+  UserSearchResult,
 } from './utils/Interfaces.js';
 import { AggregatedVolumeData } from './utils/api/queries/AggregatedMevVolume.js';
 import fs from 'fs';
@@ -87,12 +90,6 @@ export function startAbsoluteLabelsRankingClient(socket: Socket) {
   handleErrors(socket, '/main');
 }
 
-export interface LabelRankingShort {
-  address: string;
-  label: string;
-  occurrences: number;
-}
-
 /**
  * same as startAbsoluteLabelsRankingClient with an additional field numOfAllTx
  * Example:
@@ -120,12 +117,6 @@ export function startSandwichLabelOccurrencesClient(socket: Socket) {
 
   handleErrors(socket, '/main');
 }
-export interface LabelRankingExtended {
-  address: string;
-  label: string;
-  occurrences: number;
-  numOfAllTx: number;
-}
 
 // Convert user input into pool-suggestions, returns ranked pool suggestions (Pool-Name and Pool-Address)
 export function startUserSearchClient(socket: Socket, userInput: string) {
@@ -138,10 +129,7 @@ export function startUserSearchClient(socket: Socket, userInput: string) {
   handleErrors(socket, '/main');
 }
 
-export interface UserSearchResult {
-  address: string;
-  name: string | null;
-}
+
 
 /**
  * Example for enrichedSandwich

--- a/src/models/TransactionType.ts
+++ b/src/models/TransactionType.ts
@@ -1,0 +1,5 @@
+export enum TransactionType {
+  Swap = 'swap',
+  Deposit = 'deposit',
+  Remove = 'remove',
+}

--- a/src/models/Transactions.ts
+++ b/src/models/Transactions.ts
@@ -18,13 +18,8 @@ import { RawTxLogs } from './RawTxLogs.js';
 import { TransactionCoins } from './TransactionCoins.js';
 import { TransactionDetails } from './TransactionDetails.js'; // Import TransactionDetails
 import { TransactionTrace } from './TransactionTrace.js';
+import { TransactionType } from './TransactionType.js';
 import { Receipts } from './Receipts.js';
-
-export enum TransactionType {
-  Swap = 'swap',
-  Deposit = 'deposit',
-  Remove = 'remove',
-}
 
 @Index(['event_id'])
 @Table({ tableName: 'transactions' })
@@ -118,3 +113,16 @@ export type TransactionData = Pick<
   | 'value_usd'
   | 'event_id'
 > & { tx_id?: number };
+
+export interface TransactionCoin {
+  tx_id: number;
+  coin_id: number;
+  amount: string;
+  dollar_value: null | string;
+  direction: 'in' | 'out';
+  coin_symbol: string | null;
+}
+
+export interface ExtendedTransactionData extends TransactionData {
+  transactionCoins: TransactionCoin[];
+}

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -1,4 +1,4 @@
-import { TransactionData, TransactionType } from '../models/Transactions.js';
+import { TransactionType } from '../models/TransactionType.js';
 
 export interface EventObject {
   address: string;
@@ -81,19 +81,6 @@ export interface TransactionCoinRecord {
   dollar_value?: number | null;
   direction: 'in' | 'out';
   coin_symbol: string | null;
-}
-
-export interface TransactionCoin {
-  tx_id: number;
-  coin_id: number;
-  amount: string;
-  dollar_value: null | string;
-  direction: 'in' | 'out';
-  coin_symbol: string | null;
-}
-
-export interface ExtendedTransactionData extends TransactionData {
-  transactionCoins: TransactionCoin[];
 }
 
 export interface SandwichLoss {
@@ -362,3 +349,21 @@ export interface DurationType {
 export type DurationInput = DurationType | string;
 
 export type IntervalInput = DurationType | 'max';
+
+export interface LabelRankingShort {
+  address: string;
+  label: string;
+  occurrences: number;
+}
+
+export interface LabelRankingExtended {
+  address: string;
+  label: string;
+  occurrences: number;
+  numOfAllTx: number;
+}
+
+export interface UserSearchResult {
+  address: string;
+  name: string | null;
+}

--- a/src/utils/TokenPrices/txValue/PriceTransaction.ts
+++ b/src/utils/TokenPrices/txValue/PriceTransaction.ts
@@ -1,6 +1,5 @@
 import { TransactionCoins } from '../../../models/TransactionCoins.js';
-import { Transactions } from '../../../models/Transactions.js';
-import { ExtendedTransactionData, TransactionCoin } from '../../Interfaces.js';
+import { Transactions, ExtendedTransactionData, TransactionCoin } from '../../../models/Transactions.js';
 import { getTokenPriceWithTimestampFromDb } from '../../postgresTables/readFunctions/PriceMap.js';
 
 export async function priceTransaction(transactionData: ExtendedTransactionData): Promise<number | null> {

--- a/src/utils/api/queries/Sandwiches.ts
+++ b/src/utils/api/queries/Sandwiches.ts
@@ -6,7 +6,8 @@ import {
   getIdsForFullSandwichTable,
   getIdsForFullSandwichTableForPool,
 } from '../../postgresTables/readFunctions/Sandwiches.js';
-import { SandwichDetail, enrichSandwiches } from '../../postgresTables/readFunctions/SandwichDetailEnrichments.js';
+import { enrichSandwiches } from '../../postgresTables/readFunctions/SandwichDetailEnrichments.js';
+import type { SandwichDetail } from '../../postgresTables/readFunctions/SandwichDetail.js';
 import { getIdByAddressCaseInsensitive } from '../../postgresTables/readFunctions/Pools.js';
 import { sequelize } from '../../../config/Database.js';
 

--- a/src/utils/fiddyResearchTM/utils/Volume.ts
+++ b/src/utils/fiddyResearchTM/utils/Volume.ts
@@ -1,4 +1,5 @@
-import { TransactionType, Transactions } from '../../../models/Transactions.js';
+import { TransactionType } from '../../../models/TransactionType.js';
+import { Transactions } from '../../../models/Transactions.js';
 import { TransactionCoins } from '../../../models/TransactionCoins.js';
 import { getSandwichContentForPoolAndTime } from '../../postgresTables/readFunctions/Sandwiches.js';
 import { fetchAtomicArbsForPoolAndTime } from '../../postgresTables/readFunctions/AtomicArbs.js';

--- a/src/utils/helperFunctions/Client.ts
+++ b/src/utils/helperFunctions/Client.ts
@@ -1,4 +1,4 @@
-import { LabelRankingExtended } from "../../Client";
+import type { LabelRankingExtended } from '../Interfaces';
 
 export function topBestPerformingLabels(labelsOccurrence: LabelRankingExtended[]): LabelRankingExtended[] {
   const topLabels = labelsOccurrence

--- a/src/utils/postgresTables/TransactionPricing.ts
+++ b/src/utils/postgresTables/TransactionPricing.ts
@@ -1,5 +1,6 @@
 import { sequelize } from '../../config/Database.js';
-import { TransactionData, TransactionType, Transactions } from '../../models/Transactions.js';
+import { TransactionType } from '../../models/TransactionType.js';
+import { TransactionData, Transactions } from '../../models/Transactions.js';
 import { QueryTypes } from 'sequelize';
 import { updatePriceMap } from './PriceMap.js';
 import { populateTransactionCoinsWithDollarValues } from './TransactionCoins.js';

--- a/src/utils/postgresTables/mevDetection/Sandwich/SandwichCandidateScreening.ts
+++ b/src/utils/postgresTables/mevDetection/Sandwich/SandwichCandidateScreening.ts
@@ -1,6 +1,5 @@
-import { ExtendedTransactionData } from '../../../Interfaces.js';
 import { calcTheLossOfCurveUserFromSandwich, saveSandwich } from './SandwichUtils.js';
-import { Transactions } from '../../../../models/Transactions.js';
+import { ExtendedTransactionData, Transactions } from '../../../../models/Transactions.js';
 import { eventFlags } from '../../../api/utils/EventFlags.js';
 import eventEmitter from '../../../goingLive/EventEmitter.js';
 import { Sandwiches } from '../../../../models/Sandwiches.js';

--- a/src/utils/postgresTables/mevDetection/Sandwich/SandwichUtils.ts
+++ b/src/utils/postgresTables/mevDetection/Sandwich/SandwichUtils.ts
@@ -1,16 +1,18 @@
-import { Op } from "sequelize";
-import { TransactionCoins } from "../../../../models/TransactionCoins.js";
-import { TransactionData } from "../../../../models/Transactions.js";
-import { ExtendedTransactionData, SandwichLoss, TransactionCoin, TransactionCoinRecord } from "../../../Interfaces.js";
-import { findCoinSymbolById } from "../../readFunctions/Coins.js";
-import { WEB3_HTTP_PROVIDER, getTokenTransferEvents, getTxFromTxId } from "../../../web3Calls/generic.js";
-import { getAbiBy } from "../../Abi.js";
-import { LossTransaction, Sandwiches } from "../../../../models/Sandwiches.js";
-import { readSandwichesInBatches, readSandwichesInBatchesForBlock } from "../../readFunctions/Sandwiches.js";
-import { calculateLossForDeposit, calculateLossForSwap, calculateLossForWithdraw } from "./VictimLossFromSandwich.js";
-import { IsSandwich } from "../../../../models/IsSandwich.js";
+import { Op } from 'sequelize';
+import { TransactionCoins } from '../../../../models/TransactionCoins.js';
+import { ExtendedTransactionData, TransactionCoin, TransactionData } from '../../../../models/Transactions.js';
+import { SandwichLoss, TransactionCoinRecord } from '../../../Interfaces.js';
+import { findCoinSymbolById } from '../../readFunctions/Coins.js';
+import { WEB3_HTTP_PROVIDER, getTokenTransferEvents, getTxFromTxId } from '../../../web3Calls/generic.js';
+import { getAbiBy } from '../../Abi.js';
+import { LossTransaction, Sandwiches } from '../../../../models/Sandwiches.js';
+import { readSandwichesInBatches, readSandwichesInBatchesForBlock } from '../../readFunctions/Sandwiches.js';
+import { calculateLossForDeposit, calculateLossForSwap, calculateLossForWithdraw } from './VictimLossFromSandwich.js';
+import { IsSandwich } from '../../../../models/IsSandwich.js';
 
-export async function enrichCandidateWithCoinInfo(candidate: TransactionData[]): Promise<ExtendedTransactionData[] | null> {
+export async function enrichCandidateWithCoinInfo(
+  candidate: TransactionData[]
+): Promise<ExtendedTransactionData[] | null> {
   // Extract tx_ids from candidate array
   const txIds = candidate.map((transaction) => transaction.tx_id);
 

--- a/src/utils/postgresTables/mevDetection/Sandwich/VictimLossFromSandwich.ts
+++ b/src/utils/postgresTables/mevDetection/Sandwich/VictimLossFromSandwich.ts
@@ -1,10 +1,16 @@
-import { ExtendedTransactionData, SandwichLoss } from "../../../Interfaces.js";
-import { getContractByPoolID } from "../../../helperFunctions/Web3.js";
-import { web3Call } from "../../../web3Calls/generic.js";
-import { findCoinAddressById, findCoinDecimalsById, findCoinSymbolById, getLpTokenIdByPoolId } from "../../readFunctions/Coins.js";
-import { getCoinPositionInPoolByCoinId, getVersionBy } from "../../readFunctions/Pools.js";
-import { getEventById, getReturnValuesByEventId } from "../../readFunctions/RawLogs.js";
-import { findMatchingTokenTransferAmout, requiresDepositParam } from "./SandwichUtils.js";
+import { SandwichLoss } from '../../../Interfaces.js';
+import { ExtendedTransactionData } from '../../../../models/Transactions.js';
+import { getContractByPoolID } from '../../../helperFunctions/Web3.js';
+import { web3Call } from '../../../web3Calls/generic.js';
+import {
+  findCoinAddressById,
+  findCoinDecimalsById,
+  findCoinSymbolById,
+  getLpTokenIdByPoolId,
+} from '../../readFunctions/Coins.js';
+import { getCoinPositionInPoolByCoinId, getVersionBy } from '../../readFunctions/Pools.js';
+import { getEventById, getReturnValuesByEventId } from '../../readFunctions/RawLogs.js';
+import { findMatchingTokenTransferAmout, requiresDepositParam } from './SandwichUtils.js';
 
 export async function calculateLossForSwap(parsedTx: ExtendedTransactionData): Promise<SandwichLoss | null> {
   if (!parsedTx.event_id) return null;

--- a/src/utils/postgresTables/readFunctions/SandwichDetail.ts
+++ b/src/utils/postgresTables/readFunctions/SandwichDetail.ts
@@ -1,0 +1,24 @@
+import { TransactionDetail } from '../../Interfaces.js';
+
+export interface UserLossDetail {
+    unit: string;
+    unitAddress: string;
+    amount: number;
+    lossInPercentage: number;
+  }
+  
+  export interface SandwichDetail {
+    frontrun: TransactionDetail;
+    center: TransactionDetail[];
+    backrun: TransactionDetail;
+    user_losses_details: UserLossDetail[];
+    label: string;
+    poolAddress: string;
+    poolName: string;
+    lossInUsd: number;
+  }
+  
+  export interface SandwichTableContent {
+    data: SandwichDetail[];
+    totalSandwiches: number;
+  }

--- a/src/utils/postgresTables/readFunctions/SandwichDetailEnrichments.ts
+++ b/src/utils/postgresTables/readFunctions/SandwichDetailEnrichments.ts
@@ -3,31 +3,9 @@ import { TransactionDetail } from '../../Interfaces.js';
 import { getModifiedPoolName } from '../../api/utils/SearchBar.js';
 import { getLabelNameFromAddress } from './Labels.js';
 import { getAddressById } from './Pools.js';
+import { SandwichDetail, UserLossDetail } from './SandwichDetail.js';
 import { getLossInUsdForSandwich } from './Sandwiches.js';
 import { txDetailEnrichment } from './TxDetailEnrichment.js';
-
-export interface UserLossDetail {
-  unit: string;
-  unitAddress: string;
-  amount: number;
-  lossInPercentage: number;
-}
-
-export interface SandwichDetail {
-  frontrun: TransactionDetail;
-  center: TransactionDetail[];
-  backrun: TransactionDetail;
-  user_losses_details: UserLossDetail[];
-  label: string;
-  poolAddress: string;
-  poolName: string;
-  lossInUsd: number;
-}
-
-export interface SandwichTableContent {
-  data: SandwichDetail[];
-  totalSandwiches: number;
-}
 
 export async function SandwichDetailEnrichment(id: number): Promise<SandwichDetail | null> {
   const sandwich = await Sandwiches.findOne({

--- a/src/utils/postgresTables/readFunctions/Sandwiches.ts
+++ b/src/utils/postgresTables/readFunctions/Sandwiches.ts
@@ -3,7 +3,8 @@ import { LossTransaction, Sandwiches } from '../../../models/Sandwiches.js';
 import { Transactions } from '../../../models/Transactions.js';
 import { getPoolIdByPoolAddress } from './Pools.js';
 import { getTimeframeTimestamp } from '../../api/utils/Timeframes.js';
-import { SandwichDetail, enrichSandwiches } from './SandwichDetailEnrichments.js';
+import { SandwichDetail } from './SandwichDetail.js';
+import { enrichSandwiches } from './SandwichDetailEnrichments.js';
 import { sequelize } from '../../../config/Database.js';
 
 export async function readSandwichesInBatches(

--- a/src/utils/postgresTables/readFunctions/Transactions.ts
+++ b/src/utils/postgresTables/readFunctions/Transactions.ts
@@ -1,5 +1,6 @@
 import { Op, Sequelize, col, fn } from 'sequelize';
-import { Transactions, TransactionData, TransactionType } from '../../../models/Transactions.js';
+import { TransactionType } from '../../../models/TransactionType.js';
+import { Transactions, TransactionData } from '../../../models/Transactions.js';
 import { TransactionCoins } from '../../../models/TransactionCoins.js';
 
 export async function findTransactionsByPoolIdAndHash(pool_id: number, tx_hash: string): Promise<TransactionData[]> {

--- a/src/utils/postgresTables/txParsing/ParseAddLiquidity.ts
+++ b/src/utils/postgresTables/txParsing/ParseAddLiquidity.ts
@@ -1,5 +1,5 @@
 import { saveCoins, saveTransaction, transactionExists } from './ParsingHelper.js';
-import { TransactionType } from '../../../models/Transactions.js';
+import { TransactionType } from '../../../models/TransactionType.js';
 import { getCoinsBy } from '../readFunctions/Pools.js';
 import { getCoinIdByAddress, findCoinDecimalsById } from '../readFunctions/Coins.js';
 import { Coin } from '../../Interfaces.js';

--- a/src/utils/postgresTables/txParsing/ParseRemoveLiquidity.ts
+++ b/src/utils/postgresTables/txParsing/ParseRemoveLiquidity.ts
@@ -1,5 +1,5 @@
 import { saveCoins, saveTransaction } from './ParsingHelper.js';
-import { TransactionType } from '../../../models/Transactions.js';
+import { TransactionType } from '../../../models/TransactionType.js';
 import { getCoinsBy } from '../readFunctions/Pools.js';
 import { getCoinIdByAddress, findCoinDecimalsById } from '../readFunctions/Coins.js';
 import { Coin } from '../../Interfaces.js';

--- a/src/utils/postgresTables/txParsing/ParseRemoveLiquidityImbalance.ts
+++ b/src/utils/postgresTables/txParsing/ParseRemoveLiquidityImbalance.ts
@@ -1,5 +1,5 @@
 import { saveCoins, saveTransaction, transactionExists } from './ParsingHelper.js';
-import { TransactionType } from '../../../models/Transactions.js';
+import { TransactionType } from '../../../models/TransactionType.js';
 import { getCoinsBy } from '../readFunctions/Pools.js';
 import { getCoinIdByAddress, findCoinDecimalsById } from '../readFunctions/Coins.js';
 import { Coin } from '../../Interfaces.js';

--- a/src/utils/postgresTables/txParsing/ParseRemoveLiquidityOne.ts
+++ b/src/utils/postgresTables/txParsing/ParseRemoveLiquidityOne.ts
@@ -1,5 +1,5 @@
 import { saveTransaction, saveCoins, transactionExists } from './ParsingHelper.js';
-import { TransactionType } from '../../../models/Transactions.js';
+import { TransactionType } from '../../../models/TransactionType.js';
 import { getTxReceiptClassic } from '../../web3Calls/generic.js';
 import { getCoinIdByAddress, findCoinDecimalsById } from '../readFunctions/Coins.js';
 import { decodeTransferEventFromReceipt } from '../../helperFunctions/Web3.js';

--- a/src/utils/postgresTables/txParsing/ParseTokenExchange.ts
+++ b/src/utils/postgresTables/txParsing/ParseTokenExchange.ts
@@ -1,5 +1,5 @@
 import { saveCoins, saveTransaction, transactionExists } from './ParsingHelper.js';
-import { TransactionType } from '../../../models/Transactions.js';
+import { TransactionType } from '../../../models/TransactionType.js';
 import { getCoinIdByAddress, findCoinDecimalsById } from '../readFunctions/Coins.js';
 
 export async function parseTokenExchange(event: any, BLOCK_UNIXTIME: any, POOL_COINS: any): Promise<void> {

--- a/src/utils/postgresTables/txParsing/ParseTokenExchangeUnderlying.ts
+++ b/src/utils/postgresTables/txParsing/ParseTokenExchangeUnderlying.ts
@@ -1,5 +1,5 @@
 import { saveCoins, saveTransaction } from './ParsingHelper.js';
-import { TransactionType } from '../../../models/Transactions.js';
+import { TransactionType } from '../../../models/TransactionType.js';
 import { getCoinsBy, getPoolIdByPoolAddress, getBasePoolBy } from '../readFunctions/Pools.js';
 import { getCoinIdByAddress, findCoinDecimalsById } from '../readFunctions/Coins.js';
 import { findTransactionsByPoolIdAndHash } from '../readFunctions/Transactions.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,7 @@
     "sourceMap": true,
     "target": "es2017",
     "outDir": "./dist",
-    "experimentalDecorators": true,
-    "watch": true
+    "experimentalDecorators": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "sourceMap": true,
     "target": "es2017",
     "outDir": "./dist",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR:

1. Extracts `LabelRankingExtended`, `LabelRankingShort` and `UserSearchResult` from `Client.ts` and puts them into `Interfaces.ts`.
2. Extracts the `TransactionType` enum from `Transactions.ts` into a new `TransactionType.ts` file. This is because enums cannot be imported with `import type` and have to be imported with just `import`, which also causes Typescript to import other imports rescursively.
3. Move `TransactionCoin` and `ExtendedTransactionData` into `Transactions.ts` as it extends `TransactionData` which is a rich object importing a lot of things. The goal is to not have `Interface.ts` import that type as it pulls in a lot of other imports as well.
4. Because of 3, `Interfaces.ts` no longer imports `Transactions.js`.
5. Extract `SandwichTableContent`, `SandwichDetail` and `UserLossDetail` into `SandwichDetail` to if you want these types you're no longer forced to import `SandwichDetailEnrichments` and all its dependencies.

Additionally:
1. Remove the 'watch' option from tsconfig as it's an outdated property. Use `tsc --watch` instead.
2. Add `"skipLibCheck": true`, as without it the typscript compiler tries to type check *.d.ts files from sequalize-typescript.